### PR TITLE
Fix Bible rendering and improve offline UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,15 +19,15 @@
       color: #fff;
       font-size: var(--font-size);
       font-family: sans-serif;
-      padding-top: 4.5rem; /* espacio por header fijo */
+      padding-top: 6rem; /* espacio por header fijo */
     }
     #controls {
       position: fixed;
       top: 0; left: 0; right: 0;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.75rem;
+      gap: 0.75rem;
+      padding: 1rem;
       background: #111;
       z-index: 100;
       box-shadow: 0 2px 5px rgba(0,0,0,0.5);
@@ -36,8 +36,8 @@
     #controls button,
     #controls select,
     #controls input {
-      font-size: 1.2rem;
-      padding: 0.4rem;
+      font-size: 1.4rem;
+      padding: 0.6rem;
       background: #222;
       color: #fff;
       border: 1px solid #444;
@@ -49,7 +49,7 @@
       padding: 1rem;
       line-height: 1.6;
       overflow-y: auto;
-      height: calc(100vh - 4.5rem);
+      height: calc(100vh - 6rem);
     }
     #content v,
     #content h2 {
@@ -199,34 +199,26 @@
       const hdr = document.getElementById('controls').offsetHeight;
       let currentTitle = null;
       // Detectar capítulo visible
-      document.querySelectorAll('.chapter-title').forEach(title => {
-        const r = title.getBoundingClientRect();
-        if (r.top <= hdr + 5) currentTitle = title;
-      });
-      if (currentTitle) {
-        const cont = currentTitle.parentElement;
-        const b = parseInt(cont.dataset.book, 10);
-        const c = parseInt(cont.dataset.chap, 10);
-        updateSelectors(b, c);
-        fillVerses(b, c);
-        // Actualizar selector de versículo según el primer versículo visible
-        const verses = Array.from(cont.querySelectorAll('[data-verse]'));
-        for (let vEl of verses) {
-          const vr = vEl.getBoundingClientRect();
-          if (vr.top >= hdr + 5) {
-            vs.value = vEl.dataset.verse;
-            break;
-          }
+    document.querySelectorAll('.chapter-title').forEach(title => {
+      const r = title.getBoundingClientRect();
+      if (r.top <= hdr + 5) currentTitle = title;
+    });
+    if (currentTitle) {
+      const cont = currentTitle.parentElement;
+      const b = parseInt(cont.dataset.book, 10);
+      const c = parseInt(cont.dataset.chap, 10);
+      updateSelectors(b, c);
+      fillVerses(b, c);
+      // Actualizar selector de versículo según el primer versículo visible
+      const verses = Array.from(cont.querySelectorAll('[data-verse]'));
+      for (let vEl of verses) {
+        const vr = vEl.getBoundingClientRect();
+        if (vr.top >= hdr + 5) {
+          vs.value = vEl.dataset.verse;
+          break;
         }
       }
-    });
-      if (currentTitle) {
-        const cont = currentTitle.parentElement;
-        const b = parseInt(cont.dataset.book);
-        const c = parseInt(cont.dataset.chap);
-        updateSelectors(b, c);
-        fillVerses(b, c);
-      }
+    }
     }
 
     function updateSelectors(b, c) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,3 @@
-js
 const CACHE_NAME = 'biblia-app-v2';
 const urlsToCache = [
   '/',
@@ -19,12 +18,12 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('activate', event => {
-  // Limpiar cachés antiguos
+  // Limpiar cachés antiguos y tomar control inmediato
   event.waitUntil(
     caches.keys().then(keys => Promise.all(
       keys.filter(key => key !== CACHE_NAME)
           .map(key => caches.delete(key))
-    ))
+    )).then(() => self.clients.claim())
   );
 });
 


### PR DESCRIPTION
## Summary
- enlarge header controls for easier filtering on small screens
- fix scroll sync logic so verses render again
- repair service worker and claim clients for full offline support

## Testing
- `node --check service-worker.js && echo 'syntax ok'`

------
https://chatgpt.com/codex/tasks/task_e_689a9c0d6b78832d9a29cd488dc9eacc