### PR TITLE
Add offline voice navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
     <select id="bookSelect" aria-label="Seleccionar libro"></select>
     <select id="chapterSelect" aria-label="Seleccionar capítulo"></select>
     <select id="verseSelect" aria-label="Seleccionar versículo"></select>
+    <button id="voiceBtn" aria-label="Buscar por voz">🎤</button>
   </div>
   <div id="settings" aria-label="Configuraciones">
     <button id="decrease" aria-label="Disminuir tamaño de letra">A-</button>
@@ -383,5 +384,6 @@
       adjustLayout();
     });
   </script>
+  <script src="voice.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'biblia-app-v2';
+const CACHE_NAME = 'biblia-app-v3';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -6,7 +6,8 @@ const urlsToCache = [
   '/service-worker.js',
   '/manifest.json',
   '/icon-192.png',
-  '/icon-512.png'
+  '/icon-512.png',
+  '/voice.js'
 ];
 
 self.addEventListener('install', event => {

--- a/voice.js
+++ b/voice.js
@@ -1,0 +1,55 @@
+// voice.js
+// Reconocimiento de voz para navegar la Biblia
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('voiceBtn');
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    btn.style.display = 'none';
+    return;
+  }
+  const recognition = new SpeechRecognition();
+  recognition.lang = 'es-ES';
+  recognition.interimResults = false;
+  recognition.maxAlternatives = 1;
+
+  btn.addEventListener('click', () => {
+    recognition.start();
+  });
+
+  recognition.addEventListener('result', (e) => {
+    const text = e.results[0][0].transcript.toLowerCase();
+    handleCommand(text);
+  });
+
+  function normalize(str) {
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  }
+
+  function handleCommand(text) {
+    const normText = normalize(text);
+    const numbers = normText.match(/\d+/g) || [];
+    const bookNames = getBooks().map(b => normalize(b.getAttribute('n').toLowerCase()));
+    const bookIdx = bookNames.findIndex(name => normText.includes(name));
+    if (bookIdx === -1) return;
+    const chapter = numbers[0] ? Math.max(0, parseInt(numbers[0], 10) - 1) : 0;
+    const verse = numbers[1] ? parseInt(numbers[1], 10) : null;
+
+    bs.value = bookIdx;
+    fillChapters();
+    cs.value = chapter;
+    initBuffer(bookIdx, chapter);
+    fillVerses(bookIdx, chapter);
+    if (verse) {
+      vs.value = verse;
+      const el = document.querySelector(`[data-verse="${verse}"]`);
+      if (el) {
+        const hdrH = document.getElementById('controls').offsetHeight;
+        contentDiv.scrollTop = el.offsetTop - hdrH - 10;
+      }
+      updateURL(bookIdx, chapter, verse);
+    } else {
+      updateURL(bookIdx, chapter, vs.value);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add mic button and voice.js to navigate bible by spoken book, chapter and verse
- cache voice script in service worker for offline use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aacdd2750832db694d0881fe63592